### PR TITLE
No need to wait after Wire.requestFrom()

### DIFF
--- a/LSM303DLH.cpp
+++ b/LSM303DLH.cpp
@@ -98,8 +98,6 @@ void LSM303DLH::read()
 	Wire.endTransmission();
 	Wire.requestFrom(ACC_ADDRESS,6);
 
-	while (Wire.available() < 6);
-	
 	uint8_t xla = Wire.read();
 	uint8_t xha = Wire.read();
 	uint8_t yla = Wire.read();
@@ -116,8 +114,6 @@ void LSM303DLH::read()
 	Wire.write(OUT_X_H_M);
 	Wire.endTransmission();
 	Wire.requestFrom(MAG_ADDRESS,6);
-
-	while (Wire.available() < 6);
 
 	uint8_t xhm = Wire.read();
 	uint8_t xlm = Wire.read();


### PR DESCRIPTION
After the Wire.requestFrom() there is no need to wait for something.

I know this is an old file and that it is forked, but the base is no longer actively developed and you are part of the Arduino team. Therefor I would like to make these changes to prevent that others follow the incorrect use of the Wire library.